### PR TITLE
Marked the nuget package as a Development Dependency

### DIFF
--- a/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
+++ b/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
@@ -13,6 +13,7 @@
 		<PackageProjectUrl>https://github.com/nventive/Uno.MonoAnalyzers</PackageProjectUrl>
 		<PackageIconUrl>https://nv-assets.azurewebsites.net/logos/uno.png</PackageIconUrl>
 		<RepositoryUrl>https://github.com/nventive/Uno.MonoAnalyzers</RepositoryUrl>
+		<DevelopmentDependency>True</DevelopmentDependency>
 		<Description>
 			A set of Roslyn C# analyzers for Xamarin and Mono-based code bases.
 		</Description>


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
Updated the NuGet metadata to mark Mono.Analyzers as a development dependency

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Mono.Analyzers is installed without stating that it is a development dependency, resulting in it being considered as a NuGet dependency


## What is the new behavior?
Mono.Analyzers will be installed as a development dependency, and not propagated as a NuGet dependency.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ X] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
